### PR TITLE
[REFACTOR] 불필요한 조회 쿼리 제거 및 jwt 로그인 방식 수정

### DIFF
--- a/src/main/java/univ/kgu/carely/domain/member/dto/CustomUserDetails.java
+++ b/src/main/java/univ/kgu/carely/domain/member/dto/CustomUserDetails.java
@@ -33,4 +33,8 @@ public class CustomUserDetails implements UserDetails {
     public String getUsername() {
         return member.getUsername();
     }
+
+    public Long getMemberId() {
+        return member.getMemberId();
+    }
 }

--- a/src/main/java/univ/kgu/carely/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/member/service/impl/MemberServiceImpl.java
@@ -40,6 +40,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<ResMemberPublicInfoDTO> searchNeighborMember() {
         Member member = currentMember();
 
@@ -116,6 +117,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ResMemberPrivateInfoDTO getPrivateInfo(){
         Member member = currentMember();
 
@@ -151,7 +153,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public ResMemberPublicInfoDTO getMemberPublicInfo(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow();
 

--- a/src/main/java/univ/kgu/carely/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/member/service/impl/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package univ.kgu.carely.domain.member.service.impl;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ import univ.kgu.carely.domain.member.entity.Member;
 import univ.kgu.carely.domain.member.repository.MemberRepository;
 import univ.kgu.carely.domain.member.service.MemberService;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
@@ -33,7 +35,8 @@ public class MemberServiceImpl implements MemberService {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
         if(principal instanceof CustomUserDetails c){
-            return memberRepository.findByUsername(c.getUsername());
+            log.info("{}", c.getMemberId());
+            return memberRepository.getReferenceById(c.getMemberId());
         }
 
         return null;

--- a/src/main/java/univ/kgu/carely/domain/team/repository/comment/CommentRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/comment/CommentRepository.java
@@ -1,4 +1,4 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.comment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import univ.kgu.carely.domain.team.entity.Comment;

--- a/src/main/java/univ/kgu/carely/domain/team/repository/post/CustomPostRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/post/CustomPostRepository.java
@@ -1,4 +1,4 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.post;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/univ/kgu/carely/domain/team/repository/post/PostRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/post/PostRepository.java
@@ -1,4 +1,4 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.post;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import univ.kgu.carely.domain.team.entity.Post;

--- a/src/main/java/univ/kgu/carely/domain/team/repository/post/impl/PostRepositoryImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/post/impl/PostRepositoryImpl.java
@@ -1,8 +1,7 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.post.impl;
 
 import static univ.kgu.carely.domain.member.entity.QMember.member;
 import static univ.kgu.carely.domain.team.entity.QComment.comment;
-import static univ.kgu.carely.domain.team.entity.QTeam.team;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -15,6 +14,7 @@ import univ.kgu.carely.domain.member.dto.response.ResMemberSmallInfoDTO;
 import univ.kgu.carely.domain.team.dto.response.ResPostOutlineDTO;
 import univ.kgu.carely.domain.team.entity.QPost;
 import univ.kgu.carely.domain.team.entity.Team;
+import univ.kgu.carely.domain.team.repository.post.CustomPostRepository;
 
 @RequiredArgsConstructor
 public class PostRepositoryImpl implements CustomPostRepository {

--- a/src/main/java/univ/kgu/carely/domain/team/repository/team/CustomTeamRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/team/CustomTeamRepository.java
@@ -1,4 +1,4 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.team;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/univ/kgu/carely/domain/team/repository/team/TeamMateRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/team/TeamMateRepository.java
@@ -1,4 +1,4 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.team;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/univ/kgu/carely/domain/team/repository/team/TeamRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/team/TeamRepository.java
@@ -1,4 +1,4 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.team;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import univ.kgu.carely.domain.team.entity.Team;

--- a/src/main/java/univ/kgu/carely/domain/team/repository/team/impl/TeamRepositoryImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/repository/team/impl/TeamRepositoryImpl.java
@@ -1,4 +1,4 @@
-package univ.kgu.carely.domain.team.repository;
+package univ.kgu.carely.domain.team.repository.team.impl;
 
 import static univ.kgu.carely.domain.team.entity.QTeamMate.teamMate;
 
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import univ.kgu.carely.domain.member.entity.Member;
 import univ.kgu.carely.domain.team.dto.response.ResTeamOutlineDTO;
 import univ.kgu.carely.domain.team.entity.QTeam;
+import univ.kgu.carely.domain.team.repository.team.CustomTeamRepository;
 
 @RequiredArgsConstructor
 public class TeamRepositoryImpl implements CustomTeamRepository {

--- a/src/main/java/univ/kgu/carely/domain/team/service/impl/CommentServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/service/impl/CommentServiceImpl.java
@@ -10,9 +10,9 @@ import univ.kgu.carely.domain.team.dto.response.ResCommentDTO;
 import univ.kgu.carely.domain.team.entity.Comment;
 import univ.kgu.carely.domain.team.entity.Post;
 import univ.kgu.carely.domain.team.entity.Team;
-import univ.kgu.carely.domain.team.repository.CommentRepository;
-import univ.kgu.carely.domain.team.repository.PostRepository;
-import univ.kgu.carely.domain.team.repository.TeamMateRepository;
+import univ.kgu.carely.domain.team.repository.comment.CommentRepository;
+import univ.kgu.carely.domain.team.repository.post.PostRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamMateRepository;
 import univ.kgu.carely.domain.team.service.CommentService;
 
 @Service

--- a/src/main/java/univ/kgu/carely/domain/team/service/impl/CommentServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/service/impl/CommentServiceImpl.java
@@ -13,6 +13,7 @@ import univ.kgu.carely.domain.team.entity.Team;
 import univ.kgu.carely.domain.team.repository.comment.CommentRepository;
 import univ.kgu.carely.domain.team.repository.post.PostRepository;
 import univ.kgu.carely.domain.team.repository.team.TeamMateRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
 import univ.kgu.carely.domain.team.service.CommentService;
 
 @Service
@@ -23,12 +24,14 @@ public class CommentServiceImpl implements CommentService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final TeamMateRepository teamMateRepository;
+    private final TeamRepository teamRepository;
 
     @Override
     @Transactional
     public Boolean createComment(Long postId, ReqCommentDTO reqCommentDTO) {
         Member member = memberService.currentMember();
-        Post post = postRepository.findById(postId).orElseThrow();
+        Post post = postRepository.findById(postId).orElseThrow(()->
+                new RuntimeException("찾으려는 게시글이 없습니다."));
         Team team = post.getTeam();
 
         if (!teamMateRepository.existsByTeamAndMember(team, member)) {
@@ -50,7 +53,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public Boolean updateComment(ReqCommentDTO reqCommentDTO, Long commentId) {
         Member member = memberService.currentMember();
-        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        Comment comment = commentRepository.getReferenceById(commentId);
 
         if (!comment.getMember().getMemberId().equals(member.getMemberId())) {
             throw new RuntimeException("본인이 작성한 댓글만 수정이 가능합니다.");
@@ -76,7 +79,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public Boolean deleteComment(Long commentId) {
         Member member = memberService.currentMember();
-        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        Comment comment = commentRepository.getReferenceById(commentId);
 
         if(!comment.getMember().getMemberId().equals(member.getMemberId())){
             throw new RuntimeException("본인이 작성한 댓글만 삭제가 가능합니다.");

--- a/src/main/java/univ/kgu/carely/domain/team/service/impl/PostServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/service/impl/PostServiceImpl.java
@@ -13,9 +13,9 @@ import univ.kgu.carely.domain.team.dto.response.ResPostDTO;
 import univ.kgu.carely.domain.team.dto.response.ResPostOutlineDTO;
 import univ.kgu.carely.domain.team.entity.Post;
 import univ.kgu.carely.domain.team.entity.Team;
-import univ.kgu.carely.domain.team.repository.PostRepository;
-import univ.kgu.carely.domain.team.repository.TeamMateRepository;
-import univ.kgu.carely.domain.team.repository.TeamRepository;
+import univ.kgu.carely.domain.team.repository.post.PostRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamMateRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
 import univ.kgu.carely.domain.team.service.CommentService;
 import univ.kgu.carely.domain.team.service.PostService;
 

--- a/src/main/java/univ/kgu/carely/domain/team/service/impl/PostServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/service/impl/PostServiceImpl.java
@@ -33,7 +33,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public ResPostDTO createPost(ReqCreatePostDTO createPostDTO, Long teamId) {
         Member member = memberService.currentMember();
-        Team team = teamRepository.findById(teamId).orElseThrow();
+        Team team = teamRepository.getReferenceById(teamId);
 
         if(!teamMateRepository.existsByTeamAndMember(team, member)){
             throw new RuntimeException("본인이 속한 그룹에만 글을 작성할 수 있습니다.");
@@ -114,7 +114,7 @@ public class PostServiceImpl implements PostService {
     @Transactional
     public Page<ResPostOutlineDTO> readPagedPost(String query, Long teamId, Pageable pageable) {
         Member member = memberService.currentMember();
-        Team team = teamRepository.findById(teamId).orElseThrow();
+        Team team = teamRepository.getReferenceById(teamId);
 
         if(!teamMateRepository.existsByTeamAndMember(team, member)) {
             throw new RuntimeException("본인이 속한 그룹의 게시글만 볼 수 있습니다.");

--- a/src/main/java/univ/kgu/carely/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/service/impl/TeamServiceImpl.java
@@ -12,8 +12,8 @@ import univ.kgu.carely.domain.team.dto.response.ResTeamOutlineDTO;
 import univ.kgu.carely.domain.team.entity.Team;
 import univ.kgu.carely.domain.team.entity.TeamMate;
 import univ.kgu.carely.domain.team.entity.TeamRole;
-import univ.kgu.carely.domain.team.repository.TeamMateRepository;
-import univ.kgu.carely.domain.team.repository.TeamRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamMateRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
 import univ.kgu.carely.domain.team.service.TeamService;
 
 @Service

--- a/src/main/java/univ/kgu/carely/domain/team/service/impl/TeamServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/team/service/impl/TeamServiceImpl.java
@@ -44,7 +44,7 @@ public class TeamServiceImpl implements TeamService {
                 .role(TeamRole.LEADER)
                 .build();
 
-        team.getTeamMates().add(teamMate);
+        teamMateRepository.save(teamMate);
 
         return true;
     }
@@ -53,7 +53,8 @@ public class TeamServiceImpl implements TeamService {
     @Transactional
     public Boolean joinTeam(Long teamId) {
         Member member = memberService.currentMember();
-        Team team = teamRepository.findById(teamId).orElseThrow();
+        Team team = teamRepository.findById(teamId).orElseThrow(()->
+                new RuntimeException("해당 그룹이 존재하지 않습니다."));
 
         Boolean alreadyExist = teamMateRepository.existsByTeamAndMember(team, member);
 
@@ -67,7 +68,7 @@ public class TeamServiceImpl implements TeamService {
                 .role(TeamRole.MATE)
                 .build();
 
-        team.getTeamMates().add(teamMate);
+        teamMateRepository.save(teamMate);
 
         return true;
     }
@@ -76,12 +77,13 @@ public class TeamServiceImpl implements TeamService {
     @Transactional
     public Boolean exitTeam(Long teamId) {
         Member member = memberService.currentMember();
-        Team team = teamRepository.findById(teamId).orElseThrow();
+        Team team = teamRepository.getReferenceById(teamId);
 
-        TeamMate teamMate = teamMateRepository.findByTeamAndMember(team, member).orElseThrow();
+        TeamMate teamMate = teamMateRepository.findByTeamAndMember(team, member).orElseThrow(()->
+                new RuntimeException("소속이 아닌 그룹을 탈퇴할 수 없습니다."));
 
         if(teamMate.getRole().equals(TeamRole.LEADER)){
-            throw new RuntimeException("그룹장은 그룹을 탈퇴할 수 없습니다!");
+            throw new RuntimeException("그룹장은 그룹을 탈퇴할 수 없습니다.");
         }
 
         teamMateRepository.delete(teamMate);
@@ -93,9 +95,10 @@ public class TeamServiceImpl implements TeamService {
     @Transactional
     public Boolean closeTeam(Long teamId) {
         Member member = memberService.currentMember();
-        Team team = teamRepository.findById(teamId).orElseThrow();
+        Team team = teamRepository.getReferenceById(teamId);
 
-        TeamMate teamMate = teamMateRepository.findByTeamAndMember(team, member).orElseThrow();
+        TeamMate teamMate = teamMateRepository.findByTeamAndMember(team, member).orElseThrow(()->
+                new RuntimeException("소속이 아닌 그룹을 탈퇴할 수 없습니다."));
 
         if(!teamMate.getRole().equals(TeamRole.LEADER)){
             throw new RuntimeException("그룹장만 그룹을 해체할 수 있습니다.");

--- a/src/main/java/univ/kgu/carely/dummy/CommentDummy.java
+++ b/src/main/java/univ/kgu/carely/dummy/CommentDummy.java
@@ -1,0 +1,52 @@
+package univ.kgu.carely.dummy;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import univ.kgu.carely.domain.member.entity.Member;
+import univ.kgu.carely.domain.member.repository.MemberRepository;
+import univ.kgu.carely.domain.team.entity.Comment;
+import univ.kgu.carely.domain.team.entity.Post;
+import univ.kgu.carely.domain.team.repository.comment.CommentRepository;
+import univ.kgu.carely.domain.team.repository.post.PostRepository;
+
+@Configuration
+@RequiredArgsConstructor
+@Profile("default")
+public class CommentDummy {
+
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    public void makeComment() {
+        Member referMem1 = memberRepository.getReferenceById(1L);
+        Member referMem2 = memberRepository.getReferenceById(2L);
+        Member referMem3 = memberRepository.getReferenceById(3L);
+
+        Post post = postRepository.getReferenceById(1L);
+        Post post1 = postRepository.getReferenceById(2L);
+
+        Comment comment = Comment.builder()
+                .content("안뇽하세용")
+                .post(post)
+                .member(referMem2)
+                .build();
+
+        Comment comment1 = Comment.builder()
+                .content("반갑습니다!")
+                .post(post)
+                .member(referMem3)
+                .build();
+
+        Comment comment2 = Comment.builder()
+                .content("ㅎㅎㅎㅎ")
+                .post(post1)
+                .member(referMem1)
+                .build();
+
+        commentRepository.saveAll(List.of(comment, comment1, comment2));
+    }
+
+}

--- a/src/main/java/univ/kgu/carely/dummy/DummyRunner.java
+++ b/src/main/java/univ/kgu/carely/dummy/DummyRunner.java
@@ -16,6 +16,8 @@ public class DummyRunner {
     private final TeamMateDummy teamMateDummy;
     private final ChatRoomDummy chatRoomDummy;
     private final ChatMemberDummy chatMemberDummy;
+    private final PostDummy postDummy;
+    private final CommentDummy commentDummy;
 
     @Bean
     public CommandLineRunner runner() {
@@ -25,6 +27,8 @@ public class DummyRunner {
             teamMateDummy.makeTeamMate();
             chatRoomDummy.makeChatRoom();
             chatMemberDummy.makeChatMember();
+            postDummy.makePost();
+            commentDummy.makeComment();
         };
     }
 

--- a/src/main/java/univ/kgu/carely/dummy/PostDummy.java
+++ b/src/main/java/univ/kgu/carely/dummy/PostDummy.java
@@ -1,0 +1,46 @@
+package univ.kgu.carely.dummy;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import univ.kgu.carely.domain.member.entity.Member;
+import univ.kgu.carely.domain.member.repository.MemberRepository;
+import univ.kgu.carely.domain.team.entity.Post;
+import univ.kgu.carely.domain.team.entity.Team;
+import univ.kgu.carely.domain.team.repository.post.PostRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
+
+@Configuration
+@RequiredArgsConstructor
+@Profile("default")
+public class PostDummy {
+
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final TeamRepository teamRepository;
+
+    public void makePost() {
+        Member referMem1 = memberRepository.getReferenceById(1L);
+        Member referMem2 = memberRepository.getReferenceById(2L);
+        Team referTeam1 = teamRepository.getReferenceById(1L);
+
+        Post post = Post.builder()
+                .title("안녕!")
+                .content("하세욥")
+                .member(referMem1)
+                .team(referTeam1)
+                .build();
+
+        Post post1 = Post.builder()
+                .title("히히")
+                .content("하하")
+                .member(referMem2)
+                .team(referTeam1)
+                .build();
+
+        postRepository.saveAll(List.of(post, post1));
+
+    }
+
+}

--- a/src/main/java/univ/kgu/carely/dummy/TeamDummy.java
+++ b/src/main/java/univ/kgu/carely/dummy/TeamDummy.java
@@ -9,7 +9,7 @@ import univ.kgu.carely.domain.common.embeded.Address;
 import univ.kgu.carely.domain.member.entity.Member;
 import univ.kgu.carely.domain.member.repository.MemberRepository;
 import univ.kgu.carely.domain.team.entity.Team;
-import univ.kgu.carely.domain.team.repository.TeamRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/univ/kgu/carely/dummy/TeamMateDummy.java
+++ b/src/main/java/univ/kgu/carely/dummy/TeamMateDummy.java
@@ -9,8 +9,8 @@ import univ.kgu.carely.domain.member.repository.MemberRepository;
 import univ.kgu.carely.domain.team.entity.Team;
 import univ.kgu.carely.domain.team.entity.TeamMate;
 import univ.kgu.carely.domain.team.entity.TeamRole;
-import univ.kgu.carely.domain.team.repository.TeamMateRepository;
-import univ.kgu.carely.domain.team.repository.TeamRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamMateRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
 
 @Configuration
 @RequiredArgsConstructor

--- a/src/main/java/univ/kgu/carely/jwt/JwtFilter.java
+++ b/src/main/java/univ/kgu/carely/jwt/JwtFilter.java
@@ -41,10 +41,12 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         String username = jwtUtil.getUsername(token);
+        Long memberId = jwtUtil.getMemberId(token);
 //        String role = jwtUtil.getRole(token);
 
         Member member = new Member();
         member.setUsername(username);
+        member.setMemberId(memberId);
 
         CustomUserDetails customUserDetails = new CustomUserDetails(member);
 

--- a/src/main/java/univ/kgu/carely/jwt/JwtUtil.java
+++ b/src/main/java/univ/kgu/carely/jwt/JwtUtil.java
@@ -24,18 +24,23 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
     }
 
-//    public String getRole(String token){
-//        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
-//    }
+    public String getRole(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Long getMemberId(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Long.class);
+    }
 
     public Boolean isExpired(String token){
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String username, String role, Long expiredMs){
+    public String createJwt(String username, String role, Long memberId, Long expiredMs){
         return Jwts.builder()
                 .claim("username",username)
                 .claim("role",role)
+                .claim("memberId", memberId)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)

--- a/src/main/java/univ/kgu/carely/jwt/LoginFilter.java
+++ b/src/main/java/univ/kgu/carely/jwt/LoginFilter.java
@@ -40,8 +40,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String username = customUserDetails.getUsername();
         String role = authResult.getAuthorities().stream().iterator().next().getAuthority();
+        Long memberId = customUserDetails.getMemberId();
 
-        String token = jwtUtil.createJwt(username, role, EXPIRED_MS);
+        String token = jwtUtil.createJwt(username, role, memberId, EXPIRED_MS);
 
         response.addHeader("Authorization", "Bearer " + token);
     }

--- a/src/test/java/univ/kgu/carely/domain/team/repository/PostRepositoryImplTest.java
+++ b/src/test/java/univ/kgu/carely/domain/team/repository/PostRepositoryImplTest.java
@@ -1,7 +1,6 @@
 package univ.kgu.carely.domain.team.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,6 +11,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import univ.kgu.carely.domain.team.dto.response.ResPostOutlineDTO;
 import univ.kgu.carely.domain.team.entity.Team;
+import univ.kgu.carely.domain.team.repository.post.PostRepository;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/univ/kgu/carely/domain/team/repository/TeamRepositoryImplTest.java
+++ b/src/test/java/univ/kgu/carely/domain/team/repository/TeamRepositoryImplTest.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import univ.kgu.carely.domain.member.entity.Member;
 import univ.kgu.carely.domain.member.repository.MemberRepository;
 import univ.kgu.carely.domain.team.dto.response.ResTeamOutlineDTO;
+import univ.kgu.carely.domain.team.repository.team.TeamRepository;
 
 @SpringBootTest
 @ActiveProfiles("test")


### PR DESCRIPTION
# ISSUE
close #25 

# CHANGE

- [x] jwt 토큰 안에 memberId도 포함되도록 수정
- [x] ID만 필요한 경우 findById() 메서드 대신 getReferenceById() 를 이용하도록 수정
- [x] Transactional 어노테이션 추가 및 readOnly 설정이 필요한 경우 추가
- [x] Post, Comment에 해당하는 더미데이터 추가
- [x] TeamMate 영속화 과정을 더 직관적인 코드로 수정.

# ADDITIONAL

- [x] 몇몇 부분에서 에러메시지 추가
- [x] 디렉토리 세부화