### PR TITLE
[REFACTOR] MemberService의 의존성 최소화 (currentMember() 메서드 제거)

### DIFF
--- a/src/main/java/univ/kgu/carely/config/SecurityConfig.java
+++ b/src/main/java/univ/kgu/carely/config/SecurityConfig.java
@@ -63,8 +63,7 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests(auth->auth
-                        .requestMatchers("/login", "/", "/api/users/new", "/swagger-ui/**").permitAll()
-                        .requestMatchers("/admin").hasRole("USER")
+                        .requestMatchers("/api/login", "/", "/api/members/new","/api/members/check/**", "/swagger-ui/**").permitAll()
                         .anyRequest().permitAll());
 
         http.sessionManagement(session -> session

--- a/src/main/java/univ/kgu/carely/domain/meet/controller/MeetingController.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/controller/MeetingController.java
@@ -3,6 +3,7 @@ package univ.kgu.carely.domain.meet.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import univ.kgu.carely.domain.meet.dto.request.ReqMeetingCreateDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMeetingDTO;
 import univ.kgu.carely.domain.meet.service.MeetingService;
+import univ.kgu.carely.domain.member.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,24 +28,27 @@ public class MeetingController {
     @PostMapping("/new/{opponentMemberId}")
     @Operation(summary = "약속 요청 API", description = "약속을 요청(생성)한다.")
     public ResponseEntity<ResMeetingDTO> createMeeting(@PathVariable("opponentMemberId") Long opponentMemberId,
-                                                       @RequestBody ReqMeetingCreateDTO reqMeetingCreateDTO) {
-        ResMeetingDTO meeting = meetingService.createMeeting(opponentMemberId, reqMeetingCreateDTO);
+                                                       @RequestBody ReqMeetingCreateDTO reqMeetingCreateDTO,
+                                                       @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMeetingDTO meeting = meetingService.createMeeting(member, opponentMemberId, reqMeetingCreateDTO);
 
         return ResponseEntity.ok(meeting);
     }
 
     @GetMapping("/{meetingId}")
     @Operation(summary = "약속 조회 API", description = "약속을 조회한다.")
-    public ResponseEntity<ResMeetingDTO> readMeeting(@PathVariable("meetingId") Long meetingId) {
-        ResMeetingDTO meeting = meetingService.readMeeting(meetingId);
+    public ResponseEntity<ResMeetingDTO> readMeeting(@PathVariable("meetingId") Long meetingId,
+                                                     @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMeetingDTO meeting = meetingService.readMeeting(member, meetingId);
 
         return ResponseEntity.ok(meeting);
     }
 
     @PostMapping("/{meetingId}")
     @Operation(summary = "약속 수락 API", description = "약속을 수락한다.")
-    public ResponseEntity<ResMeetingDTO> acceptMeeting(@PathVariable("meetingId") Long meetingId) {
-        ResMeetingDTO meeting = meetingService.acceptMeeting(meetingId);
+    public ResponseEntity<ResMeetingDTO> acceptMeeting(@PathVariable("meetingId") Long meetingId,
+                                                       @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMeetingDTO meeting = meetingService.acceptMeeting(member, meetingId);
 
         return ResponseEntity.ok(meeting);
     }
@@ -51,32 +56,36 @@ public class MeetingController {
     @PutMapping("/{meetingId}")
     @Operation(summary = "약속 수정 API", description = "약속을 수정한다.")
     public ResponseEntity<ResMeetingDTO> updateMeeting(@PathVariable("meetingId") Long meetingId,
-                                                       @RequestBody ReqMeetingCreateDTO reqMeetingCreateDTO){
-        ResMeetingDTO meeting = meetingService.updateMeeting(meetingId, reqMeetingCreateDTO);
+                                                       @RequestBody ReqMeetingCreateDTO reqMeetingCreateDTO,
+                                                       @AuthenticationPrincipal(expression = "member") Member member){
+        ResMeetingDTO meeting = meetingService.updateMeeting(member, meetingId, reqMeetingCreateDTO);
 
         return ResponseEntity.ok(meeting);
     }
 
     @PatchMapping("/{meetingId}")
     @Operation(summary = "약속 거부 API", description = "약속을 거부한다.(PENDING 상태로 변경한다.)")
-    public ResponseEntity<ResMeetingDTO> rejectMeeting(@PathVariable("meetingId") Long meetingId) {
-        ResMeetingDTO meeting = meetingService.rejectMeeting(meetingId);
+    public ResponseEntity<ResMeetingDTO> rejectMeeting(@PathVariable("meetingId") Long meetingId,
+                                                       @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMeetingDTO meeting = meetingService.rejectMeeting(member, meetingId);
 
         return ResponseEntity.ok(meeting);
     }
 
     @DeleteMapping("/{meetingId}")
     @Operation(summary = "약속 삭제 API", description = "약속을 삭제한다.")
-    public ResponseEntity<Boolean> deleteMeeting(@PathVariable("meetingId") Long meetingId){
-        Boolean success = meetingService.deleteMeeting(meetingId);
+    public ResponseEntity<Boolean> deleteMeeting(@PathVariable("meetingId") Long meetingId,
+                                                 @AuthenticationPrincipal(expression = "member") Member member){
+        Boolean success = meetingService.deleteMeeting(member, meetingId);
 
         return ResponseEntity.ok(success);
     }
 
     @PostMapping("/{meetingId}/end")
     @Operation(summary = "약속 종료 API", description = "약속을 종료한다.")
-    public ResponseEntity<ResMeetingDTO> finishMeeting(@PathVariable("meetingId") Long meetingId) {
-        ResMeetingDTO meeting = meetingService.finishMeeting(meetingId);
+    public ResponseEntity<ResMeetingDTO> finishMeeting(@PathVariable("meetingId") Long meetingId,
+                                                       @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMeetingDTO meeting = meetingService.finishMeeting(member, meetingId);
 
         return ResponseEntity.ok(meeting);
     }

--- a/src/main/java/univ/kgu/carely/domain/meet/controller/MemoController.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/controller/MemoController.java
@@ -3,9 +3,9 @@ package univ.kgu.carely.domain.meet.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoUpdateDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoDTO;
 import univ.kgu.carely.domain.meet.service.MemoService;
+import univ.kgu.carely.domain.member.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,8 +25,9 @@ public class MemoController {
 
     @GetMapping("/current-memo")
     @Operation(summary = "최신 메모 조회 API", description = "해당 멤버의 끝난 약속중 가장 최근 메모를 조회한다.")
-    public ResponseEntity<ResMemoDTO> readCurrentFinishedMemo(@RequestParam("member_id") Long memberId) {
-        ResMemoDTO resMemoDTO = memoService.readCurrentFinishedMemo(memberId);
+    public ResponseEntity<ResMemoDTO> readCurrentFinishedMemo(@RequestParam("member_id") Long memberId,
+                                                              @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMemoDTO resMemoDTO = memoService.readCurrentFinishedMemo(member, memberId);
 
         return ResponseEntity.ok(resMemoDTO);
     }
@@ -33,16 +35,18 @@ public class MemoController {
     @PutMapping("/{meetingId}")
     @Operation(summary = "메모 수정(작성) API", description = "메모를 수정(작성)한다.")
     public ResponseEntity<ResMemoDTO> updateMemo(@PathVariable("meetingId") Long meetingId,
-                                                 @RequestBody ReqMemoUpdateDTO reqMemoUpdateDTO) {
-        ResMemoDTO resMemoDTO = memoService.updateMemo(meetingId, reqMemoUpdateDTO);
+                                                 @RequestBody ReqMemoUpdateDTO reqMemoUpdateDTO,
+                                                 @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMemoDTO resMemoDTO = memoService.updateMemo(member, meetingId, reqMemoUpdateDTO);
 
         return ResponseEntity.ok(resMemoDTO);
     }
 
     @GetMapping("/{meetingId}")
     @Operation(summary = "메모 조회 API", description = "해당 약속과 연관된 메모를 조회한다.")
-    public ResponseEntity<ResMemoDTO> readMemo(@PathVariable("meetingId") Long meetingId) {
-        ResMemoDTO resMemoDTO = memoService.readMemo(meetingId);
+    public ResponseEntity<ResMemoDTO> readMemo(@PathVariable("meetingId") Long meetingId,
+                                               @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMemoDTO resMemoDTO = memoService.readMemo(member, meetingId);
 
         return ResponseEntity.ok(resMemoDTO);
     }

--- a/src/main/java/univ/kgu/carely/domain/meet/controller/MemoryController.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/controller/MemoryController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoryUpdateDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoryDTO;
 import univ.kgu.carely.domain.meet.service.MemoryService;
+import univ.kgu.carely.domain.member.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,8 +29,9 @@ public class MemoryController {
     @GetMapping("")
     @Operation(summary = "함께한 추억 검색 API", description = "함께한 추억(방명록) 을 검색한다.")
     public ResponseEntity<Page<ResMemoryDTO>> readPagedMemory(@RequestParam(value = "query", defaultValue = "") String query,
-                                                             @PageableDefault() Pageable pageable) {
-        Page<ResMemoryDTO> resMemoryDTOS = memoryService.readPagedMemory(query, pageable);
+                                                              @PageableDefault() Pageable pageable,
+                                                              @AuthenticationPrincipal(expression = "member") Member member) {
+        Page<ResMemoryDTO> resMemoryDTOS = memoryService.readPagedMemory(member, query, pageable);
 
         return ResponseEntity.ok(resMemoryDTOS);
     }
@@ -36,16 +39,18 @@ public class MemoryController {
     @PostMapping("/{memoryId}")
     @Operation(summary = "함께한 추억 작성(수정) API", description = "함께한 추억(방명록) 을 작성한다.")
     public ResponseEntity<ResMemoryDTO> updateMemory(@PathVariable("memoryId") Long memoryId,
-                                                     @RequestBody ReqMemoryUpdateDTO reqMemoryUpdateDTO) {
-        ResMemoryDTO resMemoryDTO = memoryService.updateMemory(memoryId, reqMemoryUpdateDTO);
+                                                     @RequestBody ReqMemoryUpdateDTO reqMemoryUpdateDTO,
+                                                     @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMemoryDTO resMemoryDTO = memoryService.updateMemory(member, memoryId, reqMemoryUpdateDTO);
 
         return ResponseEntity.ok(resMemoryDTO);
     }
 
     @GetMapping("/{memoryId}")
     @Operation(summary = "함께한 추억 조회 API", description = "함께한 추억(방명록) 을 조회한다.")
-    public ResponseEntity<ResMemoryDTO> readMemory(@PathVariable("memoryId") Long memoryId) {
-        ResMemoryDTO resMemoryDTO = memoryService.readMemory(memoryId);
+    public ResponseEntity<ResMemoryDTO> readMemory(@PathVariable("memoryId") Long memoryId,
+                                                   @AuthenticationPrincipal(expression = "member") Member member) {
+        ResMemoryDTO resMemoryDTO = memoryService.readMemory(member, memoryId);
 
         return ResponseEntity.ok(resMemoryDTO);
     }

--- a/src/main/java/univ/kgu/carely/domain/meet/service/MeetingService.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/MeetingService.java
@@ -1,69 +1,76 @@
 package univ.kgu.carely.domain.meet.service;
 
-import org.springframework.transaction.annotation.Transactional;
 import univ.kgu.carely.domain.meet.dto.request.ReqMeetingCreateDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMeetingDTO;
 import univ.kgu.carely.domain.meet.entity.Meeting;
+import univ.kgu.carely.domain.member.entity.Member;
 
 public interface MeetingService {
 
     /**
      * 약속을 요청(생성)한다.
      *
+     * @param member
      * @param opponentMemberId    상대방 ID
      * @param reqMeetingCreateDTO 약속 상세 내용
      * @return 생성된 약속 정보
      */
-    ResMeetingDTO createMeeting(Long opponentMemberId, ReqMeetingCreateDTO reqMeetingCreateDTO);
+    ResMeetingDTO createMeeting(Member member, Long opponentMemberId, ReqMeetingCreateDTO reqMeetingCreateDTO);
 
     /**
-     * 약속을 조회한다. 
-     * 
+     * 약속을 조회한다.
+     *
+     * @param member
      * @param meetingId 조회할 약속 ID
      * @return 조회된 약속
      */
-    ResMeetingDTO readMeeting(Long meetingId);
+    ResMeetingDTO readMeeting(Member member, Long meetingId);
 
     /**
      * 약속을 수락한다.
      *
+     * @param member
      * @param meetingId 수락할 약속 ID
      * @return 상태가 수락으로 변경된 해당 약속
      */
-    ResMeetingDTO acceptMeeting(Long meetingId);
+    ResMeetingDTO acceptMeeting(Member member, Long meetingId);
 
     /**
      * 약속을 수정한다.
      *
+     * @param member
      * @param meetingId           수정할 약속 ID
      * @param reqMeetingCreateDTO 수정할 약속 내용
      * @return 수정된 약속
      */
-    ResMeetingDTO updateMeeting(Long meetingId, ReqMeetingCreateDTO reqMeetingCreateDTO);
+    ResMeetingDTO updateMeeting(Member member, Long meetingId, ReqMeetingCreateDTO reqMeetingCreateDTO);
 
     /**
      * 약속을 거절한다.
      *
+     * @param member
      * @param meetingId 거절하려고 하는 약속
      * @return 거절된 상태가 반영된 약속
      */
-    ResMeetingDTO rejectMeeting(Long meetingId);
+    ResMeetingDTO rejectMeeting(Member member, Long meetingId);
 
     /**
      * 약속을 삭제한다.
-     * 
+     *
+     * @param member
      * @param meetingId 삭제할 약속 ID
      * @return 약속 삭제 성공 여부
      */
-    Boolean deleteMeeting(Long meetingId);
+    Boolean deleteMeeting(Member member, Long meetingId);
 
     /**
      * 약속을 마무리한다.
      *
+     * @param member
      * @param meetingId 마무리 하려고 하는 약속 ID
      * @return 마무리 처리 된 약속
      */
-    ResMeetingDTO finishMeeting(Long meetingId);
+    ResMeetingDTO finishMeeting(Member member, Long meetingId);
 
     ResMeetingDTO toResMeetingDTO(Meeting meeting);
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/service/MemoService.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/MemoService.java
@@ -3,13 +3,14 @@ package univ.kgu.carely.domain.meet.service;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoUpdateDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoDTO;
 import univ.kgu.carely.domain.meet.entity.Memo;
+import univ.kgu.carely.domain.member.entity.Member;
 
 public interface MemoService {
-    ResMemoDTO updateMemo(Long meetingId, ReqMemoUpdateDTO reqMemoUpdateDTO);
+    ResMemoDTO updateMemo(Member member, Long meetingId, ReqMemoUpdateDTO reqMemoUpdateDTO);
 
-    ResMemoDTO readCurrentFinishedMemo(Long memberId);
+    ResMemoDTO readCurrentFinishedMemo(Member member, Long memberId);
 
     ResMemoDTO toResMemoDTO(Memo memo);
 
-    ResMemoDTO readMemo(Long meetingId);
+    ResMemoDTO readMemo(Member member, Long meetingId);
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/service/MemoryService.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/MemoryService.java
@@ -2,38 +2,41 @@ package univ.kgu.carely.domain.meet.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoryUpdateDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoryDTO;
 import univ.kgu.carely.domain.meet.entity.Memory;
+import univ.kgu.carely.domain.member.entity.Member;
 
 public interface MemoryService {
 
     /**
      * 방명록을 수정한다.
      *
+     * @param member
      * @param memoryId           수정하려고 하는 방명록 ID
      * @param reqMemoryUpdateDTO 수정하려고 하는 내용
      * @return 수정된 방명록 정보
      */
-    ResMemoryDTO updateMemory(Long memoryId, ReqMemoryUpdateDTO reqMemoryUpdateDTO);
+    ResMemoryDTO updateMemory(Member member, Long memoryId, ReqMemoryUpdateDTO reqMemoryUpdateDTO);
 
     /**
      * 방명록을 조회한다.
      *
+     * @param member
      * @param memoryId 조회하려고 하는 방명록 ID
      * @return 방명록 정보
      */
-    ResMemoryDTO readMemory(Long memoryId);
+    ResMemoryDTO readMemory(Member member, Long memoryId);
 
     /**
      * 본인과 쿼리 이름이 포함된 방명록을 찾는다.
      *
+     * @param member
      * @param query    검색하려고 하는 사람 이름
      * @param pageable 페이징 정보
      * @return 해당하는 방명록 리스트
      */
-    Page<ResMemoryDTO> readPagedMemory(String query, Pageable pageable);
+    Page<ResMemoryDTO> readPagedMemory(Member member, String query, Pageable pageable);
 
     ResMemoryDTO toResMemoryDTO(Memory memory);
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/service/impl/MeetingServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/impl/MeetingServiceImpl.java
@@ -33,9 +33,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     @Transactional
-    public ResMeetingDTO createMeeting(Long opponentMemberId, ReqMeetingCreateDTO reqMeetingCreateDTO) {
-        Member member = memberService.currentMember();
-
+    public ResMeetingDTO createMeeting(Member member, Long opponentMemberId, ReqMeetingCreateDTO reqMeetingCreateDTO) {
         if (member.getMemberId().equals(opponentMemberId)) {
             throw new RuntimeException("본인에게 약속을 요청할 수 없습니다.");
         }
@@ -67,8 +65,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     @Transactional(readOnly = true)
-    public ResMeetingDTO readMeeting(Long meetingId) {
-        Member member = memberService.currentMember();
+    public ResMeetingDTO readMeeting(Member member, Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEETING_EXCEPTION_MESSAGE));
 
@@ -82,8 +79,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     @Transactional
-    public ResMeetingDTO acceptMeeting(Long meetingId) {
-        Member member = memberService.currentMember();
+    public ResMeetingDTO acceptMeeting(Member member, Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEETING_EXCEPTION_MESSAGE));
 
@@ -107,8 +103,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     @Transactional
-    public ResMeetingDTO updateMeeting(Long meetingId, ReqMeetingCreateDTO reqMeetingCreateDTO) {
-        Member member = memberService.currentMember();
+    public ResMeetingDTO updateMeeting(Member member, Long meetingId, ReqMeetingCreateDTO reqMeetingCreateDTO) {
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEETING_EXCEPTION_MESSAGE));
 
@@ -132,8 +127,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     @Transactional
-    public ResMeetingDTO rejectMeeting(Long meetingId) {
-        Member member = memberService.currentMember();
+    public ResMeetingDTO rejectMeeting(Member member, Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEETING_EXCEPTION_MESSAGE));
 
@@ -146,16 +140,15 @@ public class MeetingServiceImpl implements MeetingService {
         }
 
         meeting.setStatus(MeetingStatus.PENDING);
-        meeting.getMemos().clear();
-        Meeting save = meetingRepository.save(meeting);
+        Memo memo = memoRepository.findByMeeting(meeting);
+        memoRepository.delete(memo);
 
-        return toResMeetingDTO(save);
+        return toResMeetingDTO(meeting);
     }
 
     @Override
     @Transactional
-    public Boolean deleteMeeting(Long meetingId) {
-        Member member = memberService.currentMember();
+    public Boolean deleteMeeting(Member member, Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEETING_EXCEPTION_MESSAGE));
 
@@ -175,8 +168,7 @@ public class MeetingServiceImpl implements MeetingService {
 
     @Override
     @Transactional
-    public ResMeetingDTO finishMeeting(Long meetingId) {
-        Member member = memberService.currentMember();
+    public ResMeetingDTO finishMeeting(Member member, Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEETING_EXCEPTION_MESSAGE));
 

--- a/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoServiceImpl.java
@@ -25,8 +25,7 @@ public class MemoServiceImpl implements MemoService {
 
     @Override
     @Transactional
-    public ResMemoDTO updateMemo(Long meetingId, ReqMemoUpdateDTO reqMemoUpdateDTO) {
-        Member member = memberService.currentMember();
+    public ResMemoDTO updateMemo(Member member, Long meetingId, ReqMemoUpdateDTO reqMemoUpdateDTO) {
         Meeting meeting = meetingRepository.getReferenceById(meetingId);
         Memo memo = memoRepository.findByMeeting(meeting);
 
@@ -47,8 +46,7 @@ public class MemoServiceImpl implements MemoService {
 
     @Override
     @Transactional(readOnly = true)
-    public ResMemoDTO readCurrentFinishedMemo(Long memberId) {
-        Member member = memberService.currentMember();
+    public ResMemoDTO readCurrentFinishedMemo(Member member, Long memberId) {
         Member memoMember = memberRepository.getReferenceById(memberId);
 
         if(!meetingRepository.existsBySenderAndReceiverAndMeetingStatusIsAccept(member, memoMember)){
@@ -62,8 +60,7 @@ public class MemoServiceImpl implements MemoService {
 
     @Override
     @Transactional(readOnly = true)
-    public ResMemoDTO readMemo(Long meetingId) {
-        Member member = memberService.currentMember();
+    public ResMemoDTO readMemo(Member member, Long meetingId) {
         Meeting meeting = meetingRepository.getReferenceById(meetingId);
         Memo memo = memoRepository.findByMeeting(meeting);
 

--- a/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoryServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoryServiceImpl.java
@@ -23,9 +23,7 @@ public class MemoryServiceImpl implements MemoryService {
 
     @Override
     @Transactional
-    public ResMemoryDTO updateMemory(Long memoryId, ReqMemoryUpdateDTO reqMemoryUpdateDTO) {
-        Member member = memberService.currentMember();
-
+    public ResMemoryDTO updateMemory(Member member, Long memoryId, ReqMemoryUpdateDTO reqMemoryUpdateDTO) {
         Memory memory = memoryRepository.findById(memoryId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEMORY_EXCEPTION_MESSAGE));
 
@@ -48,8 +46,7 @@ public class MemoryServiceImpl implements MemoryService {
 
     @Override
     @Transactional(readOnly = true)
-    public ResMemoryDTO readMemory(Long memoryId) {
-        Member member = memberService.currentMember();
+    public ResMemoryDTO readMemory(Member member, Long memoryId) {
         Memory memory = memoryRepository.findById(memoryId).orElseThrow(() ->
                 new RuntimeException(NOT_EXIST_MEMORY_EXCEPTION_MESSAGE));
 
@@ -63,9 +60,7 @@ public class MemoryServiceImpl implements MemoryService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ResMemoryDTO> readPagedMemory(String query, Pageable pageable) {
-        Member member = memberService.currentMember();
-
+    public Page<ResMemoryDTO> readPagedMemory(Member member, String query, Pageable pageable) {
         return memoryRepository.findPagedMemoryByNameContaining(query, member,
                 pageable);
     }

--- a/src/main/java/univ/kgu/carely/domain/member/service/MemberService.java
+++ b/src/main/java/univ/kgu/carely/domain/member/service/MemberService.java
@@ -12,13 +12,6 @@ import univ.kgu.carely.domain.member.entity.Member;
 public interface MemberService {
 
     /**
-     * 현재 인증된 사용자 정보를 가져온다.
-     *
-     * @return 현재 인증된 사용자
-     */
-    Member currentMember();
-
-    /**
      * 인증된 동네 기준 주변 이웃을 검색한다.
      *
      * @return 검색된 데이터

--- a/src/main/java/univ/kgu/carely/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/member/service/impl/MemberServiceImpl.java
@@ -32,18 +32,6 @@ public class MemberServiceImpl implements MemberService {
     private final BCryptPasswordEncoder encoder;
 
     @Override
-    public Member currentMember(){
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        if(principal instanceof CustomUserDetails c){
-            log.info("{}", c.getMemberId());
-            return memberRepository.getReferenceById(c.getMemberId());
-        }
-
-        throw new RuntimeException("로그인이 필요합니다.");
-    }
-
-    @Override
     @Transactional(readOnly = true)
     public List<ResMemberPublicInfoDTO> searchNeighborMember(Member member, String query) {
         member = memberRepository.findById(member.getMemberId()).orElseThrow();


### PR DESCRIPTION
# ISSUE

#36 

# CHANGE

- [x] 인증 객체를 컨트롤러에서 서비스로 직접 보내도록 수정
  - [x] MeetingController
  - [x] MemoryController
  - [x] MemoController
- [x] currentMember() 메서드 제거

# ADDITIONAL

- [x] SpringSecurity의 비회원 허용 경로 추가 및 수정
- [x] PR 전 merge conflict 해결
