### PR TITLE
[FEAT] 다른 사용자의 함께한 추억 조회 API 작성

### DIFF
--- a/src/main/java/univ/kgu/carely/config/WebClientConfig.java
+++ b/src/main/java/univ/kgu/carely/config/WebClientConfig.java
@@ -4,8 +4,6 @@ import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;

--- a/src/main/java/univ/kgu/carely/domain/meet/controller/MemoryController.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/controller/MemoryController.java
@@ -57,7 +57,7 @@ public class MemoryController {
         return ResponseEntity.ok(resMemoryDTO);
     }
 
-    @GetMapping("")
+    @GetMapping("/others")
     @Operation(summary = "다른 사용자의 함께한 추억 목록 조회 API", description = "Memory 를 Card 형태의 컴포넌트에 표현하기 위한 조회 API")
     public ResponseEntity<List<ResMemoryCardDTO>> getOthersMemories(@RequestParam("mid") Long memberId,
                                                                     @AuthenticationPrincipal(expression = "member") Member auth){

--- a/src/main/java/univ/kgu/carely/domain/meet/controller/MemoryController.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/controller/MemoryController.java
@@ -1,6 +1,7 @@
 package univ.kgu.carely.domain.meet.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoryUpdateDTO;
+import univ.kgu.carely.domain.meet.dto.response.ResMemoryCardDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoryDTO;
 import univ.kgu.carely.domain.meet.service.MemoryService;
 import univ.kgu.carely.domain.member.entity.Member;
@@ -27,7 +29,7 @@ public class MemoryController {
     private final MemoryService memoryService;
 
     @GetMapping("")
-    @Operation(summary = "함께한 추억 검색 API", description = "함께한 추억(방명록) 을 검색한다.")
+    @Operation(summary = "함께한 추억 검색 API", description = "현재 로그인한 사용자의 함께한 추억(방명록) 을 검색한다.")
     public ResponseEntity<Page<ResMemoryDTO>> readPagedMemory(@RequestParam(value = "query", defaultValue = "") String query,
                                                               @PageableDefault() Pageable pageable,
                                                               @AuthenticationPrincipal(expression = "member") Member member) {
@@ -53,6 +55,15 @@ public class MemoryController {
         ResMemoryDTO resMemoryDTO = memoryService.readMemory(member, memoryId);
 
         return ResponseEntity.ok(resMemoryDTO);
+    }
+
+    @GetMapping("")
+    @Operation(summary = "다른 사용자의 함께한 추억 목록 조회 API", description = "Memory 를 Card 형태의 컴포넌트에 표현하기 위한 조회 API")
+    public ResponseEntity<List<ResMemoryCardDTO>> getOthersMemories(@RequestParam("mid") Long memberId,
+                                                                    @AuthenticationPrincipal(expression = "member") Member auth){
+        List<ResMemoryCardDTO> resMemoryCardDTOs = memoryService.getOthersMemories(memberId, auth);
+
+        return ResponseEntity.ok(resMemoryCardDTOs);
     }
 
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/dto/response/ResMemoryCardDTO.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/dto/response/ResMemoryCardDTO.java
@@ -1,6 +1,6 @@
 package univ.kgu.carely.domain.meet.dto.response;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +16,7 @@ public class ResMemoryCardDTO {
 
     private Long memoryId;
     private String oppoName;
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
     private String memo;
 
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/dto/response/ResMemoryCardDTO.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/dto/response/ResMemoryCardDTO.java
@@ -1,0 +1,22 @@
+package univ.kgu.carely.domain.meet.dto.response;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResMemoryCardDTO {
+
+    private Long memoryId;
+    private String oppoName;
+    private LocalDate createdAt;
+    private String memo;
+
+}

--- a/src/main/java/univ/kgu/carely/domain/meet/dto/response/ResMemoryCardDTO.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/dto/response/ResMemoryCardDTO.java
@@ -16,7 +16,7 @@ public class ResMemoryCardDTO {
 
     private Long memoryId;
     private String oppoName;
+    private String oppoMemo;
     private LocalDateTime createdAt;
-    private String memo;
 
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/repository/memory/CustomMemoryRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/repository/memory/CustomMemoryRepository.java
@@ -1,10 +1,14 @@
 package univ.kgu.carely.domain.meet.repository.memory;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import univ.kgu.carely.domain.meet.dto.response.ResMemoryCardDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoryDTO;
 import univ.kgu.carely.domain.member.entity.Member;
 
 public interface CustomMemoryRepository {
     Page<ResMemoryDTO> findPagedMemoryByNameContaining(String query, Member me, Pageable pageable);
+
+    List<ResMemoryCardDTO> findMemoryCardByMember(int count, Member target);
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/repository/memory/impl/MemoryRepositoryImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/repository/memory/impl/MemoryRepositoryImpl.java
@@ -90,7 +90,7 @@ public class MemoryRepositoryImpl implements CustomMemoryRepository {
                         memory.id.as("memoryId"),
                         other.name.as("oppoName"),
                         memory.createdAt,
-                        memo.as("memo")))
+                        memo.as("oppoMemo")))
                 .from(memory)
                 .where(tar.eq(target))
                 .orderBy(memory.id.desc())

--- a/src/main/java/univ/kgu/carely/domain/meet/repository/memory/impl/MemoryRepositoryImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/repository/memory/impl/MemoryRepositoryImpl.java
@@ -1,13 +1,18 @@
 package univ.kgu.carely.domain.meet.repository.memory.impl;
 
+import static univ.kgu.carely.domain.member.entity.QMember.member;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import univ.kgu.carely.domain.common.enums.MemberType;
+import univ.kgu.carely.domain.meet.dto.response.ResMemoryCardDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoryDTO;
 import univ.kgu.carely.domain.meet.entity.QMemory;
 import univ.kgu.carely.domain.meet.repository.memory.CustomMemoryRepository;
@@ -67,6 +72,30 @@ public class MemoryRepositoryImpl implements CustomMemoryRepository {
                 .fetchOne();
 
         return new PageImpl<>(fetch, pageable, l.longValue());
+    }
+
+    @Override
+    public List<ResMemoryCardDTO> findMemoryCardByMember(int count, Member target) {
+        MemberType memberType = jpaQueryFactory.select(member.memberType)
+                .from(member)
+                .where(member.eq(target))
+                .fetchOne();
+
+        QMember tar = memberType == MemberType.FAMILY ? memory.receiver : memory.sender;
+        QMember other = memberType == MemberType.FAMILY ? memory.sender : memory.receiver;
+
+        StringPath memo = memberType == MemberType.FAMILY ? memory.senderMemo : memory.receiverMemo;
+
+        return jpaQueryFactory.select(Projections.fields(ResMemoryCardDTO.class,
+                        memory.id.as("memoryId"),
+                        other.name.as("oppoName"),
+                        memory.createdAt,
+                        memo.as("memo")))
+                .from(memory)
+                .where(tar.eq(target))
+                .orderBy(memory.id.desc())
+                .limit(count)
+                .fetch();
     }
 
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/service/MemoryService.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/MemoryService.java
@@ -1,8 +1,10 @@
 package univ.kgu.carely.domain.meet.service;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoryUpdateDTO;
+import univ.kgu.carely.domain.meet.dto.response.ResMemoryCardDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoryDTO;
 import univ.kgu.carely.domain.meet.entity.Memory;
 import univ.kgu.carely.domain.member.entity.Member;
@@ -39,4 +41,6 @@ public interface MemoryService {
     Page<ResMemoryDTO> readPagedMemory(Member member, String query, Pageable pageable);
 
     ResMemoryDTO toResMemoryDTO(Memory memory);
+
+    List<ResMemoryCardDTO> getOthersMemories(Long memberId, Member auth);
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoryServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoryServiceImpl.java
@@ -1,16 +1,19 @@
 package univ.kgu.carely.domain.meet.service.impl;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoryUpdateDTO;
+import univ.kgu.carely.domain.meet.dto.response.ResMemoryCardDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoryDTO;
 import univ.kgu.carely.domain.meet.entity.Memory;
 import univ.kgu.carely.domain.meet.repository.memory.MemoryRepository;
 import univ.kgu.carely.domain.meet.service.MemoryService;
 import univ.kgu.carely.domain.member.entity.Member;
+import univ.kgu.carely.domain.member.repository.MemberRepository;
 import univ.kgu.carely.domain.member.service.MemberService;
 import univ.kgu.carely.domain.member.util.MemberMapper;
 
@@ -19,10 +22,12 @@ import univ.kgu.carely.domain.member.util.MemberMapper;
 public class MemoryServiceImpl implements MemoryService {
 
     public static final String NOT_EXIST_MEMORY_EXCEPTION_MESSAGE = "존재하지 않는 방명록입니다.";
+    public static final int DEFAULT_MEMORY_CARD_COUNT = 5;
 
     private final MemoryRepository memoryRepository;
 
     private final MemberMapper memberMapper;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
@@ -80,6 +85,15 @@ public class MemoryServiceImpl implements MemoryService {
                 .receiver(memberMapper.toResMemberSmallInfoDto(memory.getReceiver()))
                 .meetingId(memory.getMeeting().getId())
                 .build();
+    }
+
+    @Override
+    public List<ResMemoryCardDTO> getOthersMemories(Long memberId, Member auth) {
+        Member targetMem = memberRepository.getReferenceById(memberId);
+        List<ResMemoryCardDTO> cardByMember = memoryRepository.findMemoryCardByMember(DEFAULT_MEMORY_CARD_COUNT,
+                targetMem);
+
+        return cardByMember;
     }
 
 }

--- a/src/main/java/univ/kgu/carely/dummy/DummyRunner.java
+++ b/src/main/java/univ/kgu/carely/dummy/DummyRunner.java
@@ -20,6 +20,7 @@ public class DummyRunner {
     private final CommentDummy commentDummy;
     private final MeetingDummy meetingDummy;
     private final MemoDummy memoDummy;
+    private final MemoryDummy memoryDummy;
 
     @EventListener(ApplicationReadyEvent.class)
     public void runner() {
@@ -32,6 +33,7 @@ public class DummyRunner {
         commentDummy.makeComment();
         meetingDummy.makeMeeting();
         memoDummy.makeMemo();
+        memoryDummy.makeMemory();
     }
 
 }

--- a/src/main/java/univ/kgu/carely/dummy/MemoryDummy.java
+++ b/src/main/java/univ/kgu/carely/dummy/MemoryDummy.java
@@ -29,6 +29,7 @@ public class MemoryDummy {
                 .meeting(meetingRepository.getReferenceById(1L))
                 .sender(member4)
                 .receiver(flutter)
+                // ToDo : 수정 필요함.
                 .senderMemo("ㅁㄴㅇㄹ")
                 .receiverMemo("고생많으셨습니다. 다음에 또 봐요!")
                 .build();
@@ -37,6 +38,7 @@ public class MemoryDummy {
                 .meeting(meetingRepository.getReferenceById(2L))
                 .sender(member3)
                 .receiver(flutter)
+                // ToDo : 수정 필요함.
                 .senderMemo("ㅂㅈㄷㄱ")
                 .receiverMemo("고생하셨어요!")
                 .build();

--- a/src/main/java/univ/kgu/carely/dummy/MemoryDummy.java
+++ b/src/main/java/univ/kgu/carely/dummy/MemoryDummy.java
@@ -1,0 +1,47 @@
+package univ.kgu.carely.dummy;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import univ.kgu.carely.domain.meet.entity.Meeting;
+import univ.kgu.carely.domain.meet.entity.Memory;
+import univ.kgu.carely.domain.meet.repository.meeting.MeetingRepository;
+import univ.kgu.carely.domain.meet.repository.memory.MemoryRepository;
+import univ.kgu.carely.domain.member.entity.Member;
+import univ.kgu.carely.domain.member.repository.MemberRepository;
+
+@Configuration
+@Profile("default")
+@RequiredArgsConstructor
+public class MemoryDummy {
+
+    private final MemberRepository memberRepository;
+    private final MeetingRepository meetingRepository;
+    private final MemoryRepository memoryRepository;
+
+    public void makeMemory() {
+        Member flutter = memberRepository.getReferenceById(1L);
+        Member member3 = memberRepository.getReferenceById(3L);
+        Member member4 = memberRepository.getReferenceById(4L);
+
+        Memory memory1 = Memory.builder()
+                .meeting(meetingRepository.getReferenceById(1L))
+                .sender(member4)
+                .receiver(flutter)
+                .senderMemo("ㅁㄴㅇㄹ")
+                .receiverMemo("고생많으셨습니다. 다음에 또 봐요!")
+                .build();
+
+        Memory memory2 = Memory.builder()
+                .meeting(meetingRepository.getReferenceById(2L))
+                .sender(member3)
+                .receiver(flutter)
+                .senderMemo("ㅂㅈㄷㄱ")
+                .receiverMemo("고생하셨어요!")
+                .build();
+
+        memoryRepository.saveAll(List.of(memory1, memory2));
+    }
+
+}

--- a/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
+++ b/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
@@ -1,8 +1,11 @@
 package univ.kgu.carely.domain.meet.repository.memory;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,12 +23,28 @@ class MemoryRepositoryTest {
     MemberRepository memberRepository;
 
     @Test
+    @DisplayName("View Of Receiver")
     void test1() {
         Member flutter = memberRepository.getReferenceById(1L);
 
         List<ResMemoryCardDTO> cardByMember = memoryRepository.findMemoryCardByMember(5, flutter);
 
+        assertEquals("ㅂㅈㄷㄱ", cardByMember.get(0).getMemo());
+        assertEquals("회원2", cardByMember.get(0).getOppoName());
+        assertEquals("ㅁㄴㅇㄹ", cardByMember.get(1).getMemo());
+        assertEquals("회원3", cardByMember.get(1).getOppoName());
+        assertThrows(IndexOutOfBoundsException.class, () -> cardByMember.get(3));
+    }
 
+    @Test
+    @DisplayName("View Of Sender")
+    void test2() {
+        Member member3 = memberRepository.getReferenceById(3L);
+
+        List<ResMemoryCardDTO> cardByMember = memoryRepository.findMemoryCardByMember(5, member3);
+
+        assertThat(cardByMember.get(0).getOppoName()).isEqualTo("박성민");
+        assertThat(cardByMember.get(0).getMemo()).contains("고생");
     }
 
 }

--- a/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
+++ b/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
@@ -1,4 +1,31 @@
+package univ.kgu.carely.domain.meet.repository.memory;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import univ.kgu.carely.domain.meet.dto.response.ResMemoryCardDTO;
+import univ.kgu.carely.domain.member.entity.Member;
+import univ.kgu.carely.domain.member.repository.MemberRepository;
+
+@SpringBootTest
 class MemoryRepositoryTest {
-  
+
+    @Autowired
+    MemoryRepository memoryRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void test1() {
+        Member flutter = memberRepository.getReferenceById(1L);
+
+        List<ResMemoryCardDTO> cardByMember = memoryRepository.findMemoryCardByMember(5, flutter);
+
+
+    }
+
 }

--- a/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
+++ b/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
@@ -29,9 +29,9 @@ class MemoryRepositoryTest {
 
         List<ResMemoryCardDTO> cardByMember = memoryRepository.findMemoryCardByMember(5, flutter);
 
-        assertEquals("ㅂㅈㄷㄱ", cardByMember.get(0).getMemo());
+        assertEquals("ㅂㅈㄷㄱ", cardByMember.get(0).getOppoMemo());
         assertEquals("회원2", cardByMember.get(0).getOppoName());
-        assertEquals("ㅁㄴㅇㄹ", cardByMember.get(1).getMemo());
+        assertEquals("ㅁㄴㅇㄹ", cardByMember.get(1).getOppoMemo());
         assertEquals("회원3", cardByMember.get(1).getOppoName());
         assertThrows(IndexOutOfBoundsException.class, () -> cardByMember.get(3));
     }
@@ -44,7 +44,7 @@ class MemoryRepositoryTest {
         List<ResMemoryCardDTO> cardByMember = memoryRepository.findMemoryCardByMember(5, member3);
 
         assertThat(cardByMember.get(0).getOppoName()).isEqualTo("박성민");
-        assertThat(cardByMember.get(0).getMemo()).contains("고생");
+        assertThat(cardByMember.get(0).getOppoMemo()).contains("고생");
     }
 
 }

--- a/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
+++ b/src/test/java/univ/kgu/carely/domain/meet/repository/memory/MemoryRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MemoryRepositoryTest {
+  
+}


### PR DESCRIPTION
# ISSUE

close #73 
기존의 코드를 건드리지 않고 새로운 API 엔드포인트를 만들어서 관련 부분을 따로 요청하도록 만들었습니다.

# CHANGE

- [x] 다른 사용자의 함께한 추억 조회 API 작성

# ADDITIONAL

# ToDo

- [x] `MemoryDummy.class` 의 더미데이터에 수정 필요. 어떤 메모리를 작성하는게 좋을지 모르겠음.