### PR TITLE
[FEAT] 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,9 +15,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 5s
-#  carely_ai:
-#    container_name: carely_ai
-#    image: whrjsgml0000/carely_ai:1
-#    restart: always
-#    ports:
-#      - '8000:8000'
+  carely_ai:
+    container_name: carely_ai
+    image: whrjsgml0000/carely_ai:1.0.3
+    restart: always
+    ports:
+      - '8000:8000'
+    environment:
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY}

--- a/src/main/java/univ/kgu/carely/domain/meet/controller/MemoController.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/controller/MemoController.java
@@ -50,7 +50,7 @@ public class MemoController {
     @GetMapping("/{memberId}")
     @Operation(summary = "메모 조회 API", description = "해당 멤버와 연관된 메모를 조회한다.")
     public ResponseEntity<Page<ResMemoDTO>> readMemo(@PathVariable("memberId") Long memberId,
-                                                     @PageableDefault(sort = {"memoId"}, direction = Direction.DESC) Pageable pageable,
+                                                     @PageableDefault(sort = {"id"}, direction = Direction.DESC) Pageable pageable,
                                                      @AuthenticationPrincipal(expression = "member") Member auth) {
         Page<ResMemoDTO> resMemoDTO = memoService.readMemo(memberId, auth, pageable);
 

--- a/src/main/java/univ/kgu/carely/domain/meet/controller/MemoController.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/controller/MemoController.java
@@ -2,10 +2,15 @@ package univ.kgu.carely.domain.meet.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,11 +37,22 @@ public class MemoController {
         return ResponseEntity.ok(resMemoDTO);
     }
 
+    @PostMapping("/{memberId}")
+    @Operation(summary = "메모 생성 API", description = "메모를 생성한다.")
+    public ResponseEntity<ResMemoDTO> createMemo(@PathVariable("memberId") Long memberId,
+                                                 @RequestBody ReqMemoUpdateDTO reqMemoUpdateDTO,
+                                                 @AuthenticationPrincipal(expression = "member") Member auth) {
+        ResMemoDTO resultFuture = memoService.createMemo(memberId, reqMemoUpdateDTO, auth);
+
+        return ResponseEntity.ok(resultFuture);
+    }
+
     @GetMapping("/{memberId}")
-    @Operation(summary = "메모 조회 API", description = "해당 약속과 연관된 메모를 조회한다.")
-    public ResponseEntity<ResMemoDTO> readMemo(@PathVariable("memberId") Long memberId,
-                                               @AuthenticationPrincipal(expression = "member") Member auth) {
-        ResMemoDTO resMemoDTO = memoService.readMemo(memberId, auth);
+    @Operation(summary = "메모 조회 API", description = "해당 멤버와 연관된 메모를 조회한다.")
+    public ResponseEntity<Page<ResMemoDTO>> readMemo(@PathVariable("memberId") Long memberId,
+                                                     @PageableDefault(sort = {"memoId"}, direction = Direction.DESC) Pageable pageable,
+                                                     @AuthenticationPrincipal(expression = "member") Member auth) {
+        Page<ResMemoDTO> resMemoDTO = memoService.readMemo(memberId, auth, pageable);
 
         return ResponseEntity.ok(resMemoDTO);
     }

--- a/src/main/java/univ/kgu/carely/domain/meet/entity/Memo.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/entity/Memo.java
@@ -21,6 +21,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import univ.kgu.carely.domain.member.entity.Member;
 
+// TODO : Entity 업데이트됨. 마이그레이션 파일에 해당 내용 추가 필요
+
 @Entity
 @Getter
 @Setter
@@ -60,6 +62,6 @@ public class Memo {
     // 연관 관계 설정
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/repository/memo/MemoRepository.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/repository/memo/MemoRepository.java
@@ -1,8 +1,12 @@
 package univ.kgu.carely.domain.meet.repository.memo;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import univ.kgu.carely.domain.meet.entity.Meeting;
 import univ.kgu.carely.domain.meet.entity.Memo;
+import univ.kgu.carely.domain.member.entity.Member;
 
 public interface MemoRepository extends JpaRepository<Memo, Long>, CustomMemoRepository {
+    Page<Memo> findMemoByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/repository/memo/impl/MemoRepositoryImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/repository/memo/impl/MemoRepositoryImpl.java
@@ -18,6 +18,7 @@ public class MemoRepositoryImpl implements CustomMemoRepository {
     public Memo findMemoByMember(Member member) {
         return jpaQueryFactory.selectFrom(memo)
                 .where(memo.member.eq(member))
+                .orderBy(memo.id.desc())
                 .fetchFirst();
     }
 

--- a/src/main/java/univ/kgu/carely/domain/meet/service/MemoService.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/MemoService.java
@@ -1,5 +1,7 @@
 package univ.kgu.carely.domain.meet.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import univ.kgu.carely.domain.meet.dto.request.ReqMemoUpdateDTO;
 import univ.kgu.carely.domain.meet.dto.response.ResMemoDTO;
 import univ.kgu.carely.domain.member.entity.Member;
@@ -7,5 +9,7 @@ import univ.kgu.carely.domain.member.entity.Member;
 public interface MemoService {
     ResMemoDTO updateMemo(Long memberId, Member auth, ReqMemoUpdateDTO reqMemoUpdateDTO);
 
-    ResMemoDTO readMemo(Long memberId, Member member);
+    Page<ResMemoDTO> readMemo(Long memberId, Member member, Pageable pageable);
+
+    ResMemoDTO createMemo(Long memberId, ReqMemoUpdateDTO reqMemoUpdateDTO, Member auth);
 }

--- a/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoServiceImpl.java
+++ b/src/main/java/univ/kgu/carely/domain/meet/service/impl/MemoServiceImpl.java
@@ -84,6 +84,9 @@ public class MemoServiceImpl implements MemoService {
         Memo memo = new Memo();
         memoMapper.updateMemo(memo, block);
 
+        Member member = memberRepository.getReferenceById(memberId);
+        memo.setMember(member);
+
         Memo save = memoRepository.save(memo);
 
         return memoMapper.toResMemoDto(save);

--- a/src/main/java/univ/kgu/carely/domain/member/entity/Member.java
+++ b/src/main/java/univ/kgu/carely/domain/member/entity/Member.java
@@ -116,7 +116,7 @@ public class Member {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
-    private Set<Memo> memos = new HashSet<>();
+    private List<Memo> memos = new ArrayList<>();
 
     @OneToMany(mappedBy = "sender")
     @Builder.Default


### PR DESCRIPTION
# ISSUE

close #85 

# CHANGE

- [x] 메모를 생성하는 API 추가. 사용방법은 기존의 사용방법에서 요청을 POST로 바꾸면 됨. 기존 루트도 아직 존재하므로 사용 유의 필요
- [x] 메모를 페이징 처리하여 조회하는 API 추가. `GET /api/memos/{조회하려는 멤버의 memberId}` 따로 메모를 조회하는 API는 없음. 해당 API에서 메모의 모든 정보를 주므로 프론트엔드에서 구현만 하면 됨.

# ADDITIONAL
